### PR TITLE
✨Feat: input 및 textArea 글자수 표기

### DIFF
--- a/src/app/main/layout.tsx
+++ b/src/app/main/layout.tsx
@@ -11,9 +11,5 @@ export default function MainPageLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return (
-    <html lang="ko">
-      <body>{children}</body>
-    </html>
-  );
+  return <div>{children}</div>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,9 +26,11 @@ export default function Home() {
             <h1 className="text-[48px] font-bold">모든 일정을 한눈에, 함께하는 즐거움!</h1>
             <p className="text-[24px] font-semibold mb-[51px]">캘린더로 일정을 공유하고, 모임을 만들고, 소통하세요.</p>
 
-            <Button buttonSize="normal" bgColor="filled" className="w-[110px] h-[42px]  bg-blue-33 text-xl">
-              <Link href="/main">시작하기</Link>
-            </Button>
+            <Link href="/main">
+              <Button buttonSize="normal" bgColor="filled" className="w-[110px] h-[42px]  bg-blue-33 text-xl">
+                시작하기
+              </Button>
+            </Link>
           </div>
         </Section>
 

--- a/src/components/commons/input/Input.tsx
+++ b/src/components/commons/input/Input.tsx
@@ -8,6 +8,8 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   register?: UseFormRegisterReturn;
   error?: FieldError;
   onChange?: ChangeEventHandler<HTMLInputElement>;
+  inputCount?: number;
+  maxLength?: number;
 }
 
 type InputSize = 'normal';
@@ -16,7 +18,19 @@ const inputClasses = {
   normal: 'w-full',
 };
 
-const Input = ({ title, inputSize, className, register, type, name, placeholder, error, onChange }: InputProps) => {
+const Input = ({
+  title,
+  inputSize,
+  className,
+  register,
+  type,
+  name,
+  placeholder,
+  error,
+  onChange,
+  inputCount,
+  maxLength,
+}: InputProps) => {
   const inputClass = twMerge(inputClasses[inputSize], className);
   return (
     <div className="flex flex-col">
@@ -31,8 +45,15 @@ const Input = ({ title, inputSize, className, register, type, name, placeholder,
         placeholder={placeholder}
         onChange={onChange}
         className={`${inputClass} h-[50px] rounded-lg px-4 py-3 border border-gray-d9 focus:border-gray-98`}
+        maxLength={maxLength}
       />
-      <div>{error?.message && <span className="text-[14px] text-red">{error.message}</span>}</div>
+      <div className={`flex ${error?.message ? 'justify-between' : 'justify-end'}`}>
+        {error?.message && <span className="text-[14px] text-red">{error.message}</span>}
+        <p className="flex justify-end text-[12px]">
+          <span>{inputCount}</span>
+          <span>/{maxLength}</span>
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/components/domains/landing/header/Header.tsx
+++ b/src/components/domains/landing/header/Header.tsx
@@ -12,13 +12,16 @@ const Header = () => {
         </Link>
 
         <div className="flex gap-3">
-          {/* 버튼 공통컴포넌트 만든 후 적용 */}
-          <Button buttonSize="normal" bgColor="filled" className="w-[110px] h-[42px] bg-blue-33 text-xl">
-            <Link href="/">회원가입</Link>
-          </Button>
-          <Button buttonSize="normal" bgColor="ghost" className="w-[110px] h-[42px] text-xl">
-            <Link href="/login">로그인</Link>
-          </Button>
+          <Link href="/">
+            <Button buttonSize="normal" bgColor="filled" className="w-[110px] h-[42px] bg-blue-33 text-xl">
+              회원가입
+            </Button>
+          </Link>
+          <Link href="/login">
+            <Button buttonSize="normal" bgColor="ghost" className="w-[110px] h-[42px] text-xl">
+              로그인
+            </Button>
+          </Link>
         </div>
       </div>
     </header>

--- a/src/components/domains/main/addSchedule/AddScheduleButton.tsx
+++ b/src/components/domains/main/addSchedule/AddScheduleButton.tsx
@@ -17,7 +17,7 @@ const AddScheduleButton = () => {
   return (
     <>
       <AddScheduleModal openModal={addScheduleOpenModal} handleModalClose={addScheduleClose} />
-      <div className="fixed right-5 bottom-5 cursor-pointer" onClick={addScheduleModalOpen}>
+      <div className="fixed right-5 bottom-5 cursor-pointer z-10" onClick={addScheduleModalOpen}>
         <Image src={whiteCircle} alt="whiteCircle" />
         <div className="absolute inset-0 flex justify-center items-center">
           <Image src={plus} alt="plus" />

--- a/src/components/domains/main/addSchedule/AddScheduleForm.tsx
+++ b/src/components/domains/main/addSchedule/AddScheduleForm.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, KeyboardEvent, useState } from 'react';
+import { ChangeEvent, forwardRef, KeyboardEvent, useState } from 'react';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
 import { MdOutlineCancel, MdKeyboardArrowLeft, MdKeyboardArrowRight } from 'react-icons/md';
 import DatePicker from 'react-datepicker';
@@ -25,7 +25,7 @@ interface AddScheduleForm {
   start: Date;
   end: Date;
   category?: string;
-  tag?: number[]; // 추후 number로 변경, 친구 태그로 변경 시 "joiner"로 필드명 변경 예정
+  tag?: number[]; // 친구 태그로 변경 시 "joiner"로 필드명 변경 예정
   description?: string;
 }
 
@@ -42,6 +42,11 @@ const AddScheduleForm = ({ handleModalClose }: AddScheduleFormProps) => {
   const [startTime, setStartTime] = useState<string | null>(null);
   const [endTime, setEndTime] = useState<string | null>(null);
   const [category, setCategory] = useState<string | null>(null);
+  const [inputCount, setInputCount] = useState<number>(0);
+
+  const handleOnInput = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setInputCount(e.target.value.length);
+  };
 
   const {
     control,
@@ -128,18 +133,23 @@ const AddScheduleForm = ({ handleModalClose }: AddScheduleFormProps) => {
   return (
     <form className="flex flex-col gap-[30px]" onSubmit={handleSubmit(onSubmit)}>
       {/* 입력한 글자수 표기 */}
-      <Input
-        title="제목"
-        type="text"
-        name="title"
-        inputSize="normal"
-        placeholder="제목"
-        register={register('title', {
-          required: '제목은 필수 입력값입니다.',
-        })}
-        error={errors.title}
-        className="h-[46px] text-[14px]"
-      />
+      <div>
+        <Input
+          title="제목"
+          type="text"
+          name="title"
+          inputSize="normal"
+          placeholder="제목"
+          register={register('title', {
+            required: '제목은 필수 입력값입니다.',
+          })}
+          onChange={handleOnInput}
+          error={errors.title}
+          className="h-[46px] text-[14px]"
+          maxLength={24}
+          inputCount={inputCount}
+        />
+      </div>
 
       <div className="w-[332px]">
         <label className="flex flex-col text-[20px] font-semibold">
@@ -268,7 +278,13 @@ const AddScheduleForm = ({ handleModalClose }: AddScheduleFormProps) => {
           id="memo"
           placeholder="메모를 입력해주세요"
           className="h-[143px] rounded-lg px-4 py-3 border border-gray-d9 focus:border-gray-98 focus:outline-none resize-none text-[14px]"
+          maxLength={500}
+          onChange={handleOnInput}
         />
+        <p className="flex justify-end text-[12px]">
+          <span>{inputCount}</span>
+          <span>/500</span>
+        </p>
       </div>
 
       <div className="flex gap-[20px]">


### PR DESCRIPTION
## 작업 주제

- [ ] UI추가
- [X] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [X] 버그 수정

## 스크린샷

## 구현 사항 설명
* input 컴포넌트에 inputCount, maxLength props 추가 -> 일정추가폼 Input에 글자수 표기
* 특정 경로로 이동 시(루트 -> 메인) <body> 태그가 중복 렌더링되는 문제 발생
-> 이유 : RootLayout에서 body 태그를 정의 했지만, 하위 레이아웃(mainLayout)에서 별도로 새로운 body를 렌더링, 상위 레이아웃의 구조를 깨트림, body 태그는 HTML 구조에서 단 하나만 존재해야 되는데, Next.js의 App router 구조상 중첩 레이아웃에서 중복 렌더링 됐기떄문에 오류가 발생함, 그래서 login의 layout처럼 html, body를 지우고 div로 감싸주었음.
